### PR TITLE
SDK-based test added + some fixes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -31,6 +31,11 @@
 	<dependencies>
 		<dependency>
 			<groupId>org.hobbit</groupId>
+			<artifactId>hobbit-java-sdk</artifactId>
+			<version>1.1.11-SNAPSHOT</version>
+		</dependency>
+		<dependency>
+			<groupId>org.hobbit</groupId>
 			<artifactId>core</artifactId>
 			<version>1.0.6</version>
 		</dependency>
@@ -97,6 +102,40 @@
 					</execution>
 				</executions>
 			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-surefire-plugin</artifactId>
+				<version>2.17</version>
+				<configuration>
+					<systemPropertyVariables>
+						<jarFilePath>${project.build.directory}/${project.build.finalName}.jar</jarFilePath>
+					</systemPropertyVariables>
+				</configuration>
+			</plugin>
+			<!--<plugin>-->
+				<!--<artifactId>maven-resources-plugin</artifactId>-->
+				<!--<version>2.7</version>-->
+				<!--<executions>-->
+					<!--<execution>-->
+						<!--<id>copy-resources</id>-->
+						<!--<phase>install</phase>-->
+						<!--<goals>-->
+							<!--<goal>copy-resources</goal>-->
+						<!--</goals>-->
+						<!--<configuration>-->
+							<!--<outputDirectory>${basedir}/target</outputDirectory>-->
+							<!--<resources>-->
+								<!--<resource>-->
+									<!--<directory>${basedir}/src/main/resources</directory>-->
+									<!--<includes>-->
+										<!--<include>*.txt</include>-->
+									<!--</includes>-->
+								<!--</resource>-->
+							<!--</resources>-->
+						<!--</configuration>-->
+					<!--</execution>-->
+				<!--</executions>-->
+			<!--</plugin>-->
 		</plugins>
 	</build>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -33,6 +33,7 @@
 			<groupId>org.hobbit</groupId>
 			<artifactId>hobbit-java-sdk</artifactId>
 			<version>1.1.11-SNAPSHOT</version>
+			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.hobbit</groupId>

--- a/src/main/java/org/hobbit/sparql_snb/SNBBenchmarkController.java
+++ b/src/main/java/org/hobbit/sparql_snb/SNBBenchmarkController.java
@@ -30,12 +30,12 @@ public class SNBBenchmarkController extends AbstractBenchmarkController {
 
 	// TODO: Add image names of containers
 	/* Data generator Docker image */
-	private static final String DATA_GENERATOR_CONTAINER_IMAGE = "git.project-hobbit.eu:4567/mspasic/dsb-datagenerator";
+	protected static final String DATA_GENERATOR_CONTAINER_IMAGE = "git.project-hobbit.eu:4567/mspasic/dsb-datagenerator";
 	/* Task generator Docker image */
-	private static final String TASK_GENERATOR_CONTAINER_IMAGE = "git.project-hobbit.eu:4567/mspasic/dsb-taskgenerator";
-	private static final String SEQ_TASK_GENERATOR_CONTAINER_IMAGE = "git.project-hobbit.eu:4567/mspasic/dsb-seqtaskgenerator";
+	protected static final String TASK_GENERATOR_CONTAINER_IMAGE = "git.project-hobbit.eu:4567/mspasic/dsb-taskgenerator";
+	protected static final String SEQ_TASK_GENERATOR_CONTAINER_IMAGE = "git.project-hobbit.eu:4567/mspasic/dsb-seqtaskgenerator";
 	/* Evaluation module Docker image */
-	private static final String EVALUATION_MODULE_CONTAINER_IMAGE = "git.project-hobbit.eu:4567/mspasic/dsb-evaluationmodule";
+	protected static final String EVALUATION_MODULE_CONTAINER_IMAGE = "git.project-hobbit.eu:4567/mspasic/dsb-evaluationmodule";
 
 	public SNBBenchmarkController() {
 

--- a/src/main/java/org/hobbit/sparql_snb/systems/VirtuosoSystemAdapter.java
+++ b/src/main/java/org/hobbit/sparql_snb/systems/VirtuosoSystemAdapter.java
@@ -37,9 +37,9 @@ public class VirtuosoSystemAdapter extends AbstractSystemAdapter {
 
 	@Override
 	public void receiveGeneratedData(byte[] data) {
-		ByteBuffer dataBuffer = ByteBuffer.wrap(data);    	
+		ByteBuffer dataBuffer = ByteBuffer.wrap(data);
     	String fileName = RabbitMQUtils.readString(dataBuffer);
-    	    	
+
     	FileOutputStream fos;
 		try {
 			fos = new FileOutputStream(System.getProperty("user.dir") + File.separator + "datasets" + File.separator + fileName);
@@ -134,9 +134,10 @@ public class VirtuosoSystemAdapter extends AbstractSystemAdapter {
     }
     
     private void internalInit() {
-		String datasetsFolderName = "datasets"; 
+		String datasetsFolderName = "datasets";
 		File theDir = new File(datasetsFolderName);
-		theDir.mkdir();
+		if (!theDir.exists())
+			theDir.mkdir();
     	
     	queryExecFactory = new QueryExecutionFactoryHttp("http://" + virtuosoContName + ":8890/sparql");
     	
@@ -172,7 +173,7 @@ public class VirtuosoSystemAdapter extends AbstractSystemAdapter {
     }
     
     private void loadDataset() {
-    	String scriptFilePath = System.getProperty("user.dir") + File.separator + "load.sh";
+    	String scriptFilePath = System.getProperty("user.dir") + File.separator + "system/load.sh";
     	String[] command = {"/bin/bash", scriptFilePath, virtuosoContName, System.getProperty("user.dir") + File.separator + "datasets", "2"};
     	Process p;
     	try {

--- a/src/test/java/org.hobbit.sparql_snb/BenchmarkTest.java
+++ b/src/test/java/org.hobbit.sparql_snb/BenchmarkTest.java
@@ -1,0 +1,174 @@
+package org.hobbit.sparql_snb;
+
+import org.hobbit.core.components.Component;
+import org.hobbit.sdk.EnvironmentVariablesWrapper;
+import org.hobbit.sdk.JenaKeyValue;
+import org.hobbit.sdk.docker.MultiThreadedImageBuilder;
+import org.hobbit.sdk.docker.RabbitMqDockerizer;
+import org.hobbit.sdk.docker.builders.hobbit.*;
+
+import org.hobbit.sdk.examples.dummybenchmark.DummyEvalStorage;
+import org.hobbit.sdk.utils.CommandQueueListener;
+import org.hobbit.sdk.utils.ComponentsExecutor;
+
+import org.hobbit.sdk.utils.commandreactions.CommandReactionsBuilder;
+import org.hobbit.sparql_snb.systems.VirtuosoSystemAdapter;
+import org.junit.Assert;
+import org.junit.Ignore;
+import org.junit.Test;
+
+import java.io.StringReader;
+import java.util.Date;
+
+import static org.hobbit.core.Constants.*;
+import static org.hobbit.sdk.CommonConstants.*;
+import static org.hobbit.sparql_snb.SNBBenchmarkController.*;
+
+/**
+ * @author Pavel Smirnov
+ */
+
+public class BenchmarkTest extends EnvironmentVariablesWrapper {
+
+    private RabbitMqDockerizer rabbitMqDockerizer;
+    private ComponentsExecutor componentsExecutor;
+    private CommandQueueListener commandQueueListener;
+
+    BenchmarkDockerBuilder benchmarkBuilder;
+    DataGenDockerBuilder dataGeneratorBuilder;
+    TaskGenDockerBuilder taskGeneratorBuilder;
+    EvalStorageDockerBuilder evalStorageBuilder;
+    SystemAdapterDockerBuilder systemAdapterBuilder;
+    EvalModuleDockerBuilder evalModuleBuilder;
+
+
+
+    public void init(Boolean useCachedImage) throws Exception {
+
+        benchmarkBuilder = new BenchmarkDockerBuilder(new CommonDockersBuilder(SNBBenchmarkController.class, "git.project-hobbit.eu:4567/mspasic/benchmark-controller").customDockerFileReader(new StringReader("docker/sparql-snbbenchmarkcontroller.docker")).useCachedImage(useCachedImage));
+        dataGeneratorBuilder = new DataGenDockerBuilder(new CommonDockersBuilder(SNBDataGenerator.class, DATA_GENERATOR_CONTAINER_IMAGE).useCachedImage(useCachedImage).customDockerFileReader(new StringReader("docker/sparql-snbdatagenerator.docker")));
+        taskGeneratorBuilder = new TaskGenDockerBuilder(new CommonDockersBuilder(SNBTaskGenerator.class, TASK_GENERATOR_CONTAINER_IMAGE).useCachedImage(useCachedImage).customDockerFileReader(new StringReader("docker/sparql-snbtaskgenerator.docker")));
+
+        evalStorageBuilder = new EvalStorageDockerBuilder(new CommonDockersBuilder(DummyEvalStorage.class, "git.project-hobbit.eu:4567/defaulthobbituser/defaultevaluationstorage:1.0.7").useCachedImage(useCachedImage));
+
+        systemAdapterBuilder = new SystemAdapterDockerBuilder(new CommonDockersBuilder(VirtuosoSystemAdapter.class, "git.project-hobbit.eu:4567/mspasic/virtuososystem").useCachedImage(useCachedImage).customDockerFileReader(new StringReader("docker/virtuososystem.docker")));
+        evalModuleBuilder = new EvalModuleDockerBuilder(new CommonDockersBuilder(SNBEvaluationModule.class, "git.project-hobbit.eu:4567/mspasic/evaluation-module").useCachedImage(useCachedImage).customDockerFileReader(new StringReader("docker/sparql-snbevaluationmodule.docker")));
+
+    }
+
+
+    @Test
+    @Ignore
+    public void buildImages() throws Exception {
+
+        init(false);
+
+        MultiThreadedImageBuilder builder = new MultiThreadedImageBuilder(5);
+        builder.addTask(benchmarkBuilder);
+        builder.addTask(dataGeneratorBuilder);
+        builder.addTask(taskGeneratorBuilder);
+        //builder.addTask(evalStorageBuilder);
+        builder.addTask(systemAdapterBuilder);
+        builder.build();
+    }
+
+    @Test
+    public void checkHealth() throws Exception {
+        checkHealth(false);
+    }
+
+    @Test
+    @Ignore
+    public void checkHealthDockerized() throws Exception {
+        checkHealth(true);
+    }
+
+    private void checkHealth(Boolean dockerized) throws Exception {
+
+        Boolean useCachedImages = true;
+        init(useCachedImages);
+
+        rabbitMqDockerizer = RabbitMqDockerizer.builder().build();
+
+        environmentVariables.set(RABBIT_MQ_HOST_NAME_KEY, rabbitMqDockerizer.getHostName());
+        environmentVariables.set(HOBBIT_SESSION_ID_KEY, "session_"+String.valueOf(new Date().getTime()));
+
+
+        Component benchmarkController = new SNBBenchmarkController();
+        Component dataGen = new SNBDataGenerator();
+        Component taskGen = new SNBTaskGenerator();
+        Component evalStorage = new DummyEvalStorage();
+
+        Component systemAdapter = new VirtuosoSystemAdapter();
+        Component evalModule = new SNBEvaluationModule();
+
+        if(dockerized) {
+
+            benchmarkController = benchmarkBuilder.build();
+            dataGen = dataGeneratorBuilder.build();
+            taskGen = taskGeneratorBuilder.build();
+            evalStorage = evalStorageBuilder.build();
+            evalModule = evalModuleBuilder.build();
+            systemAdapter = systemAdapterBuilder.build();
+        }
+
+        commandQueueListener = new CommandQueueListener();
+        componentsExecutor = new ComponentsExecutor();
+
+        rabbitMqDockerizer.run();
+
+
+        CommandReactionsBuilder commandReactionsBuilder = new CommandReactionsBuilder(componentsExecutor, commandQueueListener)
+                .benchmarkController(benchmarkController).benchmarkControllerImageName(benchmarkBuilder.getImageName())
+                .dataGenerator(dataGen).dataGeneratorImageName(dataGeneratorBuilder.getImageName())
+                .taskGenerator(taskGen).taskGeneratorImageName(taskGeneratorBuilder.getImageName())
+                .evalStorage(evalStorage).evalStorageImageName(evalStorageBuilder.getImageName())
+                .systemAdapter(systemAdapter).systemAdapterImageName(systemAdapterBuilder.getImageName())
+                .evalModule(evalModule).evalModuleImageName(evalModuleBuilder.getImageName());
+
+        commandQueueListener.setCommandReactions(
+                commandReactionsBuilder.buildStartCommandsReaction(),
+                commandReactionsBuilder.buildTerminateCommandsReaction(),
+                commandReactionsBuilder.buildPlatformCommandsReaction()
+        );
+
+
+        componentsExecutor.submit(commandQueueListener);
+        commandQueueListener.waitForInitialisation();
+
+        String benchmarkContainerId = "benchmark";
+        benchmarkContainerId = commandQueueListener.createContainer(benchmarkBuilder.getImageName(), "benchmark", new String[]{ HOBBIT_EXPERIMENT_URI_KEY+"="+EXPERIMENT_URI,  BENCHMARK_PARAMETERS_MODEL_KEY+"="+ createBenchmarkParameters() });
+        //componentsExecutor.submit(benchmarkController, benchmarkContainerId, new String[]{ HOBBIT_EXPERIMENT_URI_KEY+"="+EXPERIMENT_URI,  BENCHMARK_PARAMETERS_MODEL_KEY+"="+ createBenchmarkParameters() });
+
+
+        String systemContainerId = commandQueueListener.createContainer(systemAdapterBuilder.getImageName(), "system" ,new String[]{ SYSTEM_PARAMETERS_MODEL_KEY+"="+ createSystemParameters() });
+
+        environmentVariables.set("BENCHMARK_CONTAINER_ID", benchmarkContainerId);
+        environmentVariables.set("SYSTEM_CONTAINER_ID", systemContainerId);
+
+        //componentsExecutor.submit(systemAdapter, "system", new String[]{ SYSTEM_PARAMETERS_MODEL_KEY+"="+ createSystemParameters() });
+
+
+        commandQueueListener.waitForTermination();
+
+        rabbitMqDockerizer.stop();
+
+        Assert.assertFalse(componentsExecutor.anyExceptions());
+    }
+
+
+    public String createBenchmarkParameters() {
+        JenaKeyValue kv = new JenaKeyValue();
+
+        return kv.encodeToString();
+    }
+
+    private static String createSystemParameters(){
+        JenaKeyValue kv = new JenaKeyValue();
+        //kv.setValue(BENCHMARK_MODE_INPUT_NAME, BENCHMARK_MODE_DYNAMIC+":10:1");
+        return kv.encodeToString();
+    }
+
+
+
+}

--- a/src/test/java/org.hobbit.sparql_snb/CommonDockersBuilder.java
+++ b/src/test/java/org.hobbit.sparql_snb/CommonDockersBuilder.java
@@ -1,0 +1,20 @@
+package org.hobbit.sparql_snb;
+
+import org.hobbit.sdk.docker.builders.DynamicDockerFileBuilder;
+
+public class CommonDockersBuilder extends DynamicDockerFileBuilder {
+
+
+    public CommonDockersBuilder(Class runningClass, String imageName) throws Exception {
+        super("CommonDockersBuilder");
+        imageName(imageName);
+        buildDirectory(".");
+        jarFilePath(System.getProperty("jarFilePath"));
+        dockerWorkDir("/usr/src/sparql-snb");
+        runnerClass(org.hobbit.core.run.ComponentStarter.class, runningClass);
+        containerName(runningClass.getSimpleName());
+        //runnerClass(value);
+    }
+
+
+}


### PR DESCRIPTION
The added test allows to execute benchmark locally (docker should be installed and rabbit container started (or will be started automatically if test is running under sudo)). Just run the 'check_health()' method. `127.0.0.1 rabbit`should be added to /etc/hosts file. More info [here](https://github.com/hobbit-project/java-sdk-example)